### PR TITLE
Chapter 11 metrics split

### DIFF
--- a/chapter10/grafana-shipitclicker.json
+++ b/chapter10/grafana-shipitclicker.json
@@ -15,7 +15,7 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 14,
+  "id": 5,
   "links": [],
   "panels": [
     {
@@ -24,6 +24,12 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -113,6 +119,12 @@
       "dashes": false,
       "datasource": null,
       "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -197,19 +209,18 @@
     }
   ],
   "refresh": false,
-  "schemaVersion": 22,
+  "schemaVersion": 25,
   "style": "dark",
   "tags": [],
   "templating": {
     "list": []
   },
   "time": {
-    "from": "2020-06-11T06:58:10.914Z",
-    "to": "2020-06-16T00:12:59.225Z"
+    "from": "now-1h",
+    "to": "now"
   },
   "timepicker": {
     "refresh_intervals": [
-      "5s",
       "10s",
       "30s",
       "1m",
@@ -224,8 +235,5 @@
   "timezone": "",
   "title": "ShipIt Clicker",
   "uid": "Qislo-mGz",
-  "variables": {
-    "list": []
-  },
-  "version": 1
+  "version": 3
 }

--- a/chapter11/docker-compose.yml
+++ b/chapter11/docker-compose.yml
@@ -2,7 +2,7 @@
 version: '3'
 services:
   shipit-clicker-web-v8:
-    image: ${DOCKER_IMAGE:-dockerfordevelopers/shipitclicker:1.11.5}
+    image: ${DOCKER_IMAGE:-dockerfordevelopers/shipitclicker:1.11.7}
     build: .
     environment:
         - APP_ID=${APP_ID:-shipitclicker-v8}
@@ -10,6 +10,7 @@ services:
         - OPENAPI_SPEC=${OPENAPI_SPEC:-/api/v1/spec}
         - OPENAPI_ENABLE_RESPONSE_VALIDATION=${OPENAPI_ENABLE_RESPONSE_VALIDATION:-false}
         - PORT=3000
+        - METRICS_PORT=9090
         - LOG_LEVEL=${LOG_LEVEL:-info}
         - REQUEST_LIMIT=${REQUEST_LIMIT:-100kb}
         - REDIS_HOST=${REDIS_HOST:-redis}
@@ -21,6 +22,7 @@ services:
         - JAEGER_COLLECTOR_ENDPOINT=${JAEGER_COLLECTOR_ENDPOINT:-http://jaeger:14268/api/traces}
     ports:
         - "${PORT:-3011}:3000"
+        - "${METRICS_PORT:-9090}:9090"
     links:
       - redis
       - jaeger

--- a/chapter11/shipitclicker/Chart.yaml
+++ b/chapter11/shipitclicker/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 name: shipitclicker
 description: A Helm chart for ShipIt Clicker Kubernetes
 type: application
-version: 1.11.6
-appVersion: 1.11.5
+version: 1.11.7
+appVersion: 1.11.7

--- a/chapter11/shipitclicker/templates/configmap-envoy.yaml
+++ b/chapter11/shipitclicker/templates/configmap-envoy.yaml
@@ -50,6 +50,32 @@ data:
                   "@type": type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy
                   stat_prefix: egress_redis
                   cluster: redis_cluster
+        - name: "envoy-prometheus-http-listener"
+          address:
+            socket_address:
+              address: "0.0.0.0"
+              port_value: 9902
+          filter_chains:
+            - filters:
+              - name: "envoy.http_connection_manager"
+                typed_config:
+                  "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
+                  codec_type: auto
+                  stat_prefix: ingress_metrics
+                  route_config:
+                    name: local_route
+                    virtual_hosts:
+                    - name: local_service
+                      domains: ["*"]
+                      routes:
+                      - match:
+                          prefix: "/metrics"
+                        route:
+                          cluster: envoy_admin
+                          prefix_rewrite: "/stats/prometheus"
+                  http_filters:
+                  - name: envoy.filters.http.router
+                    typed_config: {}
       clusters:
       - name: shipitclicker_cluster
         connect_timeout: 0.25s
@@ -83,3 +109,16 @@ data:
                   socket_address:
                     address: redis-master
                     port_value: 6379
+      - name: envoy_admin
+        connect_timeout: 0.25s
+        type: static
+        load_assignment:
+          cluster_name: envoy_admin
+          endpoints:
+          - lb_endpoints:
+            - endpoint:
+                address:
+                  socket_address:
+                    address: "127.0.0.1"
+                    port_value: 9901
+

--- a/chapter11/shipitclicker/templates/configmap.yaml
+++ b/chapter11/shipitclicker/templates/configmap.yaml
@@ -7,6 +7,7 @@ data:
   OPENAPI_SPEC: "/api/v1/spec"
   OPENAPI_ENABLE_RESPONSE_VALIDATION: "false"
   PORT: "3000"
+  METRICS_PORT: "9090"
   LOG_LEVEL: "info"
   REQUEST_LIMIT: "100kb"
   REDIS_HOST: "localhost"

--- a/chapter11/shipitclicker/templates/deployment.yaml
+++ b/chapter11/shipitclicker/templates/deployment.yaml
@@ -146,6 +146,9 @@ spec:
             - name: envoy-http
               containerPort: 4000
               protocol: TCP
+            - name: metrics
+              containerPort: 9902
+              protocol: TCP
           livenessProbe:
             httpGet:
               path: /server_info

--- a/chapter11/shipitclicker/templates/deployment.yaml
+++ b/chapter11/shipitclicker/templates/deployment.yaml
@@ -52,6 +52,11 @@ spec:
                 configMapKeyRef:
                   name: {{ .Release.Name }}-configmap
                   key: OPENAPI_ENABLE_RESPONSE_VALIDATION
+            - name: METRICS_PORT
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ .Release.Name }}-configmap
+                  key: METRICS_PORT
             - name: PORT
               valueFrom:
                 configMapKeyRef:
@@ -115,6 +120,9 @@ spec:
           ports:
             - name: http
               containerPort: 3000
+              protocol: TCP
+            - name: metrics
+              containerPort: 9090
               protocol: TCP
           livenessProbe:
             httpGet:

--- a/chapter11/shipitclicker/values.yaml
+++ b/chapter11/shipitclicker/values.yaml
@@ -4,7 +4,7 @@ podDisruptionBudget:
   minAvailable: 1
 
 image:
-  repository: dockerfordevelopers/shipitclicker:1.11.5
+  repository: dockerfordevelopers/shipitclicker:1.11.7
   pullPolicy: IfNotPresent
 
 envoy:

--- a/chapter11/src/server/index.js
+++ b/chapter11/src/server/index.js
@@ -1,5 +1,8 @@
 import './common/env';
 import Server from './common/server';
 import routes from './routes';
+import metricsRoutes from './metricsRoutes';
+
+const metrics = new Server().router(metricsRoutes).listen(process.env.METRICS_PORT);
 
 export default new Server().router(routes).listen(process.env.PORT);

--- a/chapter11/src/server/metricsRoutes.js
+++ b/chapter11/src/server/metricsRoutes.js
@@ -1,0 +1,5 @@
+import metricsRouter from './api/controllers/metrics/router';
+
+export default function routes(app) {
+  app.use('/metrics', metricsRouter);
+}

--- a/chapter11/src/server/routes.js
+++ b/chapter11/src/server/routes.js
@@ -1,9 +1,7 @@
 import faultsRouter from './api/controllers/faults/router';
 import gamesRouter from './api/controllers/games/router';
-import metricsRouter from './api/controllers/metrics/router';
 
 export default function routes(app) {
   app.use('/faults', faultsRouter);
-  app.use('/metrics', metricsRouter);
   app.use('/api/v2/games', gamesRouter);
 }


### PR DESCRIPTION
This splits out the /metrics endpoint so that it no longer runs on the main http service port for ShipIt Clicker.