### PR TITLE
Fixed issue #84 blocking the version of Debian

### DIFF
--- a/chapter2/Dockerfile
+++ b/chapter2/Dockerfile
@@ -1,5 +1,5 @@
 # we will inherit from  the Debian image on DockerHub
-FROM debian
+FROM debian:10
 
 # set timezone so files' timestamps are correct
 ENV TZ=America/Los_Angeles


### PR DESCRIPTION
The Dockerfile includes the latest version of Debian, that now includes PHP 7.4.
It would be better practice to block the version of Debian used in the container.
In this way I block to Debian:10, ensuring the container will work even in the future.