### PR TITLE
Chapter5: Fixing nodejs version issue in Dockerfile

### DIFF
--- a/chapter5/Dockerfile
+++ b/chapter5/Dockerfile
@@ -1,6 +1,4 @@
-FROM ubuntu:bionic
-RUN apt-get -qq update && \
-    apt-get -qq install -y nodejs npm > /dev/null
+FROM node:10
 RUN mkdir -p /app/public /app/server
 COPY src/package.json* /app
 WORKDIR /app


### PR DESCRIPTION
Running "docker-compose up" without modifying the Dockerfile results in the following error:

```
Step 6/11 : RUN npm -s install
 ---> Running in e7f3b1bb3902
WARN engine dotenv@8.6.0: wanted: {"node":">=10"} (current: {"node":"8.10.0","npm":"3.5.2"})
WARN engine json-schema-ref-parser@9.0.9: wanted: {"node":">=10"} (current: {"node":"8.10.0","npm":"3.5.2"})
WARN engine fsevents@2.3.2: wanted: {"node":"^8.16.0 || ^10.6.0 || >=11.0.0"} (current: {"node":"8.10.0","npm":"3.5.2"})
The command '/bin/sh -c npm -s install' returned a non-zero code: 1
ERROR: Service 'shipit-clicker-web' failed to build

```
Changing the base image to "FROM node:10" appears to resolve the issue. 

