### PR TITLE
Fix all Dockerfiles to ensure they build in 2021

### DIFF
--- a/ERRATA.md
+++ b/ERRATA.md
@@ -1,11 +1,29 @@
 # Docker for Developers - companion code Errata
 
-##  Chapter 5
+## Chapter 2
+The [Dockerfile](chapter2/Dockerfile) has been modified to use `ubuntu:10` as a base container, as it is the one that has a compatible PHP 7.3 runtime that the Dockerfile relies on.
 
+
+##  Chapter 5
 The [Dockerfile](chapter5/Dockerfile) now uses `ubuntu:focal` as a base container. It originally used `ubuntu:bionic` as a base container and the now-obsolete Node 8 runtime and npm 3.5.2 within proved to be problematic in 2021. If you enabled verbose output on NPM install, it yielded an `npm ERR! code EMISSINGARG` error similar to the problem described in the [lodash issue #4358](https://github.com/lodash/lodash/issues/4358). This is the sort of problem hinted at in Chapter 6 regarding using general-purpose OS images in the "Re-examining the initial Dockerfile" section, see pp. 122-134.
 
 In switching from Ubuntu bionic (18.04) to focal (20.04) we also have to add an environment variable to the installation to force a non-interactive package installation, per [this Ask Ubuntu article](https://askubuntu.com/a/556387).
 
 
 ## Chapter 6
-The [Dockerfile](chapter6/Dockerfile) has been modified 
+The [Dockerfile](chapter6/Dockerfile) has been modified to use the Alpine `npm` package which replaces `nodejs-npm`.
+
+## Chapter 7
+The [Dockerfile](chapter7/Dockerfile) has been modified to use the Alpine `npm` package which replaces `nodejs-npm`.
+
+## Chapter 8
+The [Dockerfile](chapter8/Dockerfile) has been modified to use the Alpine `npm` package which replaces `nodejs-npm`.
+
+## Chapter 9
+The [Dockerfile](chapter9/Dockerfile) has been modified to use the Alpine `npm` package which replaces `nodejs-npm`.
+
+## Chapter 10
+The [Dockerfile](chapter10/Dockerfile) has been modified to use the Alpine `npm` package which replaces `nodejs-npm`.
+
+## Chapter 11
+The [Dockerfile](chapter11/Dockerfile) has been modified to use the Alpine `npm` package which replaces `nodejs-npm`.

--- a/ERRATA.md
+++ b/ERRATA.md
@@ -26,5 +26,8 @@ The [Dockerfile](chapter10/Dockerfile) has been modified to use the Alpine `npm`
 ## Chapter 11
 The [Dockerfile](chapter11/Dockerfile) has been modified to use the Alpine `npm` package which replaces `nodejs-npm`.
 
+## Chapter 13
+The [Dockerfile](chapter13/Dockerfile) has been modified to use the same Docker image printed in the book. You will still need to modify it before building, replacing `user@host` with a valid user and hostname for a server you control.
+
 ## Chapter 14
 The [Dockerfile](chapter14/Dockerfile) has been modified to use an Alpine base container and fixes some erroneous smart quotes that were printed correctly in the book, but not in the repository originally.

--- a/ERRATA.md
+++ b/ERRATA.md
@@ -3,12 +3,10 @@
 ## Chapter 2
 The [Dockerfile](chapter2/Dockerfile) has been modified to use `ubuntu:10` as a base container, as it is the one that has a compatible PHP 7.3 runtime that the Dockerfile relies on.
 
-
 ##  Chapter 5
 The [Dockerfile](chapter5/Dockerfile) now uses `ubuntu:focal` as a base container. It originally used `ubuntu:bionic` as a base container and the now-obsolete Node 8 runtime and npm 3.5.2 within proved to be problematic in 2021. If you enabled verbose output on NPM install, it yielded an `npm ERR! code EMISSINGARG` error similar to the problem described in the [lodash issue #4358](https://github.com/lodash/lodash/issues/4358). This is the sort of problem hinted at in Chapter 6 regarding using general-purpose OS images in the "Re-examining the initial Dockerfile" section, see pp. 122-134.
 
 In switching from Ubuntu bionic (18.04) to focal (20.04) we also have to add an environment variable to the installation to force a non-interactive package installation, per [this Ask Ubuntu article](https://askubuntu.com/a/556387).
-
 
 ## Chapter 6
 The [Dockerfile](chapter6/Dockerfile) has been modified to use the Alpine `npm` package which replaces `nodejs-npm`.

--- a/ERRATA.md
+++ b/ERRATA.md
@@ -1,0 +1,11 @@
+# Docker for Developers - companion code Errata
+
+##  Chapter 5
+
+The [Dockerfile](chapter5/Dockerfile) now uses `ubuntu:focal` as a base container. It originally used `ubuntu:bionic` as a base container and the now-obsolete Node 8 runtime and npm 3.5.2 within proved to be problematic in 2021. If you enabled verbose output on NPM install, it yielded an `npm ERR! code EMISSINGARG` error similar to the problem described in the [lodash issue #4358](https://github.com/lodash/lodash/issues/4358). This is the sort of problem hinted at in Chapter 6 regarding using general-purpose OS images in the "Re-examining the initial Dockerfile" section, see pp. 122-134.
+
+In switching from Ubuntu bionic (18.04) to focal (20.04) we also have to add an environment variable to the installation to force a non-interactive package installation, per [this Ask Ubuntu article](https://askubuntu.com/a/556387).
+
+
+## Chapter 6
+The [Dockerfile](chapter6/Dockerfile) has been modified 

--- a/ERRATA.md
+++ b/ERRATA.md
@@ -25,3 +25,6 @@ The [Dockerfile](chapter10/Dockerfile) has been modified to use the Alpine `npm`
 
 ## Chapter 11
 The [Dockerfile](chapter11/Dockerfile) has been modified to use the Alpine `npm` package which replaces `nodejs-npm`.
+
+## Chapter 14
+The [Dockerfile](chapter14/Dockerfile) has been modified to use an Alpine base container and fixes some erroneous smart quotes that were printed correctly in the book, but not in the repository originally.

--- a/README.md
+++ b/README.md
@@ -78,6 +78,9 @@ With the following software and hardware list you can run all code files present
   
 We also provide a PDF file that has color images of the screenshots/diagrams used in this book. [Click here to download it](http://www.packtpub.com/sites/default/files/downloads/9781789536058_ColorImages.pdf).
 
+## Errata
+Please see [ERRATA.md](ERRATA.md) for a list of significant changes to the code in this repository since the book was published.
+
 # Code in Action
 Click on the following link to see the Code in Action:
 

--- a/chapter10/Dockerfile
+++ b/chapter10/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:20191114
 RUN apk update && \
-    apk add nodejs nodejs-npm
+    apk add nodejs npm
 RUN addgroup -S app && adduser -S -G app app
 RUN mkdir -p /app/public /app/server
 ADD src/package.json* /app/

--- a/chapter11/Dockerfile
+++ b/chapter11/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:20191114
 RUN apk update && \
-    apk add nodejs nodejs-npm
+    apk add nodejs npm
 RUN addgroup -S app && adduser -S -G app app
 RUN mkdir -p /app/public /app/server
 ADD src/package.json* /app/

--- a/chapter13/Dockerfile
+++ b/chapter13/Dockerfile
@@ -1,13 +1,13 @@
-FROM <image> as intermediate 
+FROM dockerfordevelopers/shipitclicker@sha256:39eda93d15866957feaee28f8fc5adb545276a64147445c64992ef69804dbf01 as intermediate
 
 WORKDIR /test 
 ARG ssh_prv_key 
 RUN echo "$ssh_prv_key" > /tmp/id_rsa_test 
 RUN chmod 600 /tmp/* 
 RUN apk add openssh 
-RUN scp -i /tmp/id_rsa_test user@server:/path/to/file.txt . 
+RUN scp -i /tmp/id_rsa_test user@server:/path/to/file.txt .
 
-FROM <image>
+FROM dockerfordevelopers/shipitclicker@sha256:39eda93d15866957feaee28f8fc5adb545276a64147445c64992ef69804dbf01
  
 WORKDIR /test 
 COPY --from=intermediate /test . 

--- a/chapter14/Dockerfile
+++ b/chapter14/Dockerfile
@@ -1,6 +1,8 @@
-LABEL “version”=”1.1.2-test” 
+FROM alpine:20191114
 
-LABEL “description”=” Development environment container for testing the newest security patch. Not for production release yet” 
+LABEL "version"="1.1.2-test” 
 
-LABEL “security.txt”=”https://respository.example.com/my_project/security.txt” 
+LABEL "description"=" Development environment container for testing the newest security patch. Not for production release yet" 
+
+LABEL "security.txt"="https://respository.example.com/my_project/security.txt"
  

--- a/chapter2/Dockerfile
+++ b/chapter2/Dockerfile
@@ -1,5 +1,5 @@
 # we will inherit from  the Debian image on DockerHub
-FROM debian
+FROM debian:10
 
 # set timezone so files' timestamps are correct
 ENV TZ=America/Los_Angeles

--- a/chapter5/Dockerfile
+++ b/chapter5/Dockerfile
@@ -1,6 +1,15 @@
-FROM ubuntu:bionic
+# Note: the text of this differs from what was presented in Chapter 5
+# and Chapter 6 as the original choice of ubuntu:bionic for a base container
+# and the now-obsolete Node 8 runtime within proved to be problematic in 2021. 
+# This is the sort of problem hinted at in Chapter 6 regarding using general-purpose
+# OS images in the "Re-examining the initial Dockerfile" section, see pp. 122-134. 
+#
+# In switching from Ubuntu bionic to focal we also have to add an
+# environment variable to the install to force a non-interactive package installation,
+# per https://askubuntu.com/a/556387
+FROM ubuntu:focal
 RUN apt-get -qq update && \
-    apt-get -qq install -y nodejs npm > /dev/null
+    DEBIAN_FRONTEND=noninteractive apt-get -qq install -y nodejs npm > /dev/null
 RUN mkdir -p /app/public /app/server
 COPY src/package.json* /app
 WORKDIR /app

--- a/chapter6/Dockerfile
+++ b/chapter6/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:20191114
 RUN apk update && \
-    apk add nodejs nodejs-npm
+    apk add nodejs npm
 RUN addgroup -S app && adduser -S -G app app
 RUN mkdir -p /app/public /app/server
 ADD src/package.json* /app/

--- a/chapter7/Dockerfile
+++ b/chapter7/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:20191114
 RUN apk update && \
-    apk add nodejs nodejs-npm
+    apk add nodejs npm
 RUN addgroup -S app && adduser -S -G app app
 RUN mkdir -p /app/public /app/server
 ADD src/package.json* /app/

--- a/chapter8/Dockerfile
+++ b/chapter8/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:20191114
 RUN apk update && \
-    apk add nodejs nodejs-npm
+    apk add nodejs npm
 RUN addgroup -S app && adduser -S -G app app
 RUN mkdir -p /app/public /app/server
 ADD src/package.json* /app/

--- a/chapter9/Dockerfile
+++ b/chapter9/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:20191114
 RUN apk update && \
-    apk add nodejs nodejs-npm
+    apk add nodejs npm
 RUN addgroup -S app && adduser -S -G app app
 RUN mkdir -p /app/public /app/server
 ADD src/package.json* /app/


### PR DESCRIPTION
This adds an ERRATA.md describing the substantive changes since 
publication, and fixes all the Dockerfiles so that they continue to build,
despite some drift in the underlying software ecosystems.

Resolves #86