### PR TITLE
Added check for counter.txt, fixes issue #93

### DIFF
--- a/chapter2/public_html/index.php
+++ b/chapter2/public_html/index.php
@@ -7,6 +7,7 @@ error_reporting(E_ALL);
 
 // filename to store counter value.  sys_get_temp_dir() returns a directory with write permissions.
 //$COUNTER_FILE = sys_get_temp_dir() . '/' . 'counter.txt';
+passthru('touch /data/counter.txt');
 $COUNTER_FILE = '/data/counter.txt';
 
 // print a message

--- a/chapter2/public_html/index.php
+++ b/chapter2/public_html/index.php
@@ -7,8 +7,8 @@ error_reporting(E_ALL);
 
 // filename to store counter value.  sys_get_temp_dir() returns a directory with write permissions.
 //$COUNTER_FILE = sys_get_temp_dir() . '/' . 'counter.txt';
-passthru('touch /data/counter.txt');
 $COUNTER_FILE = '/data/counter.txt';
+if(!file_exists($COUNTER_FILE )) passthru('touch /data/counter.txt');
 
 // print a message
 print("Hello, world $COUNTER_FILE\n");

--- a/chapter2/public_html/index.php
+++ b/chapter2/public_html/index.php
@@ -8,6 +8,8 @@ error_reporting(E_ALL);
 // filename to store counter value.  sys_get_temp_dir() returns a directory with write permissions.
 //$COUNTER_FILE = sys_get_temp_dir() . '/' . 'counter.txt';
 $COUNTER_FILE = '/data/counter.txt';
+
+// check for counter.txt existence
 if(!file_exists($COUNTER_FILE )) passthru('touch /data/counter.txt');
 
 // print a message


### PR DESCRIPTION
From Issue #93 
When the container is first built and ran, the counter file does not exist, causing the warning below:

 "Warning:  file_get_contents(/data/counter.txt): failed to open stream: No such file or directory in /home/app/public_html/index.php on line 16".

![chapter2-error](https://user-images.githubusercontent.com/75383639/145275559-083e795c-f5c2-43a1-b9bf-3a3a3d5d51c1.PNG)

I added a check for this file, and if the file is not found, an empty counter.txt file is written to /data. 