### PR TITLE
Fix alpine node containers

### DIFF
--- a/ERRATA.md
+++ b/ERRATA.md
@@ -1,5 +1,7 @@
 # Docker for Developers - companion code Errata
 
+Many of the chapters have had updates to language libraries via their packaging systems (for example `npm`) to avoid security problems.
+
 ## Chapter 2
 The [Dockerfile](chapter2/Dockerfile) has been modified to use `ubuntu:10` as a base container, as it is the one that has a compatible PHP 7.3 runtime that the Dockerfile relies on.
 
@@ -9,22 +11,22 @@ The [Dockerfile](chapter5/Dockerfile) now uses `ubuntu:focal` as a base containe
 In switching from Ubuntu bionic (18.04) to focal (20.04) we also have to add an environment variable to the installation to force a non-interactive package installation, per [this Ask Ubuntu article](https://askubuntu.com/a/556387).
 
 ## Chapter 6
-The [Dockerfile](chapter6/Dockerfile) has been modified to use the Alpine `npm` package which replaces `nodejs-npm`.
+The [Dockerfile](chapter6/Dockerfile) has been modified to use `node:14-alpine` image which keeps Alpine Linux, but pins the version of node to Node 14, which is more stable than using the stock Alpine Docker container and installing Node using `apk`.
 
 ## Chapter 7
-The [Dockerfile](chapter7/Dockerfile) has been modified to use the Alpine `npm` package which replaces `nodejs-npm`.
+The [Dockerfile](chapter7/Dockerfile) has been modified to use `node:14-alpine` image which keeps Alpine Linux, but pins the version of node to Node 14, which is more stable than using the stock Alpine Docker container and installing Node using `apk`.
 
 ## Chapter 8
-The [Dockerfile](chapter8/Dockerfile) has been modified to use the Alpine `npm` package which replaces `nodejs-npm`.
+The [Dockerfile](chapter8/Dockerfile) has been modified to use `node:14-alpine` image which keeps Alpine Linux, but pins the version of node to Node 14, which is more stable than using the stock Alpine Docker container and installing Node using `apk`.
 
 ## Chapter 9
-The [Dockerfile](chapter9/Dockerfile) has been modified to use the Alpine `npm` package which replaces `nodejs-npm`.
+The [Dockerfile](chapter9/Dockerfile) has been modified to use `node:14-alpine` image which keeps Alpine Linux, but pins the version of node to Node 14, which is more stable than using the stock Alpine Docker container and installing Node using `apk`.
 
 ## Chapter 10
-The [Dockerfile](chapter10/Dockerfile) has been modified to use the Alpine `npm` package which replaces `nodejs-npm`.
+The [Dockerfile](chapter10/Dockerfile) has been modified to use `node:14-alpine` image which keeps Alpine Linux, but pins the version of node to Node 14, which is more stable than using the stock Alpine Docker container and installing Node using `apk`.
 
 ## Chapter 11
-The [Dockerfile](chapter11/Dockerfile) has been modified to use the Alpine `npm` package which replaces `nodejs-npm`.
+The [Dockerfile](chapter11/Dockerfile) has been modified to use `node:14-alpine` image which keeps Alpine Linux, but pins the version of node to Node 14, which is more stable than using the stock Alpine Docker container and installing Node using `apk`.
 
 ## Chapter 13
 The [Dockerfile](chapter13/Dockerfile) has been modified to use the same Docker image printed in the book. You will still need to modify it before building, replacing `user@host` with a valid user and hostname for a server you control.

--- a/chapter10/Dockerfile
+++ b/chapter10/Dockerfile
@@ -1,6 +1,4 @@
-FROM alpine:20191114
-RUN apk update && \
-    apk add nodejs npm
+FROM node:14-alpine
 RUN addgroup -S app && adduser -S -G app app
 RUN mkdir -p /app/public /app/server
 ADD src/package.json* /app/

--- a/chapter11/Dockerfile
+++ b/chapter11/Dockerfile
@@ -1,6 +1,4 @@
-FROM alpine:20191114
-RUN apk update && \
-    apk add nodejs npm
+FROM node:14-alpine
 RUN addgroup -S app && adduser -S -G app app
 RUN mkdir -p /app/public /app/server
 ADD src/package.json* /app/

--- a/chapter6/Dockerfile
+++ b/chapter6/Dockerfile
@@ -1,6 +1,4 @@
-FROM alpine:20191114
-RUN apk update && \
-    apk add nodejs npm
+FROM node:14-alpine
 RUN addgroup -S app && adduser -S -G app app
 RUN mkdir -p /app/public /app/server
 ADD src/package.json* /app/

--- a/chapter7/Dockerfile
+++ b/chapter7/Dockerfile
@@ -1,6 +1,4 @@
-FROM alpine:20191114
-RUN apk update && \
-    apk add nodejs npm
+FROM node:14-alpine
 RUN addgroup -S app && adduser -S -G app app
 RUN mkdir -p /app/public /app/server
 ADD src/package.json* /app/

--- a/chapter8/Dockerfile
+++ b/chapter8/Dockerfile
@@ -1,6 +1,4 @@
-FROM alpine:20191114
-RUN apk update && \
-    apk add nodejs npm
+FROM node:14-alpine
 RUN addgroup -S app && adduser -S -G app app
 RUN mkdir -p /app/public /app/server
 ADD src/package.json* /app/

--- a/chapter9/Dockerfile
+++ b/chapter9/Dockerfile
@@ -1,6 +1,4 @@
-FROM alpine:20191114
-RUN apk update && \
-    apk add nodejs npm
+FROM node:14-alpine
 RUN addgroup -S app && adduser -S -G app app
 RUN mkdir -p /app/public /app/server
 ADD src/package.json* /app/


### PR DESCRIPTION
Using the general Alpine Docker container as a base was causing multiple
problems, including the need to keep tweaking the `apk` statements
required, and the version of Node installed kept floating to the point
where the newer versions of Node were incompatible with some of the
libraries, causing the problem described here:

https://stackoverflow.com/questions/66420890/open-api-error-request-should-have-required-property-headers-docker

It is better practice to use a stable and consistent version of a
language runtime anyway.
